### PR TITLE
setting up a custom hook that handles an initial loading state, makes…

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -170,7 +170,7 @@ class AuthController {
     // send response to client
     const userDto = new UserDto(user);
 
-    res.json({ user: userDto, auth: true });
+    res.json({ user: userDto, auth: true }); // data that we are sending whenever refreshToken is updated and sent to the client
   }
 }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,9 +13,19 @@ import Home from "./pages/Home/Home";
 import Navigation from "./components/shared/Navigation/Navigation";
 import Rooms from "./pages/Rooms/Rooms";
 import { useSelector } from "react-redux";
+import { useState } from "react";
+import { useLoadingWithRefresh } from "./hooks/useLoadingWithRefresh";
+
+// Root component
 
 function App() {
-  return (
+  // call refresh endpoint
+
+  const { loading } = useLoadingWithRefresh();
+
+  return loading ? (
+    <h1>Loading ..</h1>
+  ) : (
     <Router>
       <Navigation />
       <Routes>

--- a/frontend/src/hooks/useLoadingWithRefresh.js
+++ b/frontend/src/hooks/useLoadingWithRefresh.js
@@ -1,0 +1,45 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
+import { setAuth } from "../store/authSlice";
+
+//&this code sets up a custom hook that handles an initial loading state, makes a server request to refresh the authentication, and updates the loading state accordingly. It utilizes the useEffect hook to execute the request only once when the component mounts. The loading state can be used in the consuming component to conditionally render loading indicators or handle other logic related to the loading state.
+
+export function useLoadingWithRefresh() {
+  const [loading, setLoading] = useState(true);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    // server request
+
+    (async () => {
+      try {
+        const { data } = await axios.get(
+          `${process.env.REACT_APP_API_URL}/api/refresh`,
+          {
+            withCredentials: true,
+          }
+        );
+
+        dispatch(setAuth(data));
+        setLoading(false);
+      } catch (error) {
+        console.log(error);
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  return { loading };
+}
+
+// ~------------->
+// const { data } = await axios.get(
+//   `${process.env.REACT_APP_API_URL}/api/refresh`,
+//   {
+//     withCredentials: true,
+//   }
+// );
+// dispatch(setAuth(data));
+
+// If the request is successful, the response data is extracted using destructuring and passed to the dispatch function, which likely updates the authentication state using the setAuth action creator.


### PR DESCRIPTION
feat: Implement useLoadingWithRefresh hook

This commit adds the useLoadingWithRefresh hook, which provides a convenient way to handle loading state and automatically refresh authentication when needed. The hook makes an HTTP GET request to the /api/refresh endpoint and updates the authentication state using the received data.

Key Changes:
- Added useLoadingWithRefresh hook to manage loading state and authentication refresh
- Utilized the useEffect and useState hooks to handle side effects and state management
- Implemented an asynchronous function to make the refresh request using Axios
- Dispatched the received authentication data to update the application state
- Handled loading state updates and error logging

This enhancement simplifies the implementation of loading state management and authentication refresh, improving the overall user experience and security of the application.

Fixes #1
