### PR TITLE
setting the environment variable NODE_OPTIONS in dockerfile

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -3,7 +3,8 @@ WORKDIR /frontend
 COPY ./frontend/package*.json ./
 RUN npm install
 COPY ./frontend/ ./
-ENV NODE_OPTIONS="--max-old-space-size=1536"
+# Set the NODE_OPTIONS environment variable
+ENV NODE_OPTIONS="--max-old-space-size=2048"
 RUN npm run build 
 
 


### PR DESCRIPTION
- setting the environment variable NODE_OPTIONS in dockerfile. 
-Environment variable is specific to Node.js and is used to adjust the maximum heap size limit for the Node.js process running inside the Docker container.